### PR TITLE
feat: add jest configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This package includes the following configurations:
 * [`canonical`](./configurations/eslintrc.json) – The Canonical code style guide.
 * [`canonical/ava`](./configurations/ava.json) – To be used in addition to "canonical" configuration by projects that use [AVA](https://ava.li/).
 * [`canonical/flowtype`](./configurations/flowtype.json) – To be used in addition to "canonical" configuration by projects that use [Flowtype](https://flowtype.org/).
+* [`canonical/jest`](./configurations/jest.json) – To be used in addition to "canonical" configuration by projects that use [jest](https://facebook.github.io/jest/).
 * [`canonical/lodash`](./configurations/lodash.json) – To be used in addition to "canonical" configuration by projects that use [lodash](https://lodash.com/).
 * [`canonical/mocha`](./configurations/mocha.json) – To be used in addition to "canonical" configuration by projects that use [Mocha](https://mochajs.org/).
 * [`canonical/react`](./configurations/react.json) – To be used in addition to "canonical" configuration by projects that use [React](https://facebook.github.io/react/).
@@ -26,6 +27,7 @@ Example:
     "canonical",
     "canonical/ava",
     "canonical/flowtype",
+    "canonical/jest",
     "canonical/lodash",
     "canonical/mocha",
     "canonical/react"

--- a/configurations/jest.json
+++ b/configurations/jest.json
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "jest": true
+  },
+  "plugins": [
+    "jest"
+  ],
+  "rules": {
+    "jest/no-disabled-tests": "error",
+    "jest/no-focused-tests": "error",
+    "jest/no-identical-title": "error",
+    "jest/valid-expect": "error"
+  }
+}

--- a/jest.js
+++ b/jest.js
@@ -1,0 +1,1 @@
+module.exports = require('./configurations/jest.json');

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-flowtype": "^2.34.0",
     "eslint-plugin-import": "^2.3.0",
+    "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-jsdoc": "^3.1.0",
     "eslint-plugin-lodash": "^2.4.2",
     "eslint-plugin-mocha": "^4.10.0",


### PR DESCRIPTION
Adds rules for jest to be used as `canonical/jest`