### PR TITLE
Update the babel-eslint parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "url": "http://gajus.com"
   },
   "dependencies": {
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "^8.1.2",
     "eslint-plugin-ava": "^4.2.0",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-filenames": "^1.2.0",


### PR DESCRIPTION
This is necessary, as babel-eslint<=8.1.0 is not compatible with eslint@4.14.0