### PR TITLE
`eslint-plugin-jest` v24.0.0 rule rename

### DIFF
--- a/configurations/jest.json
+++ b/configurations/jest.json
@@ -10,7 +10,7 @@
     "jest/no-disabled-tests": 2,
     "jest/no-focused-tests": 2,
     "jest/no-identical-title": 2,
-    "jest/no-test-callback": 2,
+    "jest/no-done-callback": 2,
     "jest/no-truthy-falsy": 2,
     "jest/prefer-spy-on": 2,
     "jest/prefer-to-contain": 2,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "^2.22.0",
-    "eslint-plugin-jest": "^23.18.0",
+    "eslint-plugin-jest": "^24.1.0",
     "eslint-plugin-jsdoc": "^30.0.3",
     "eslint-plugin-lodash": "^7.1.0",
     "eslint-plugin-mocha": "^7.0.1",


### PR DESCRIPTION
[v24.0.0 of `eslint-plugin-jest` renames rule `jest/no-test-callback` to `jest/no-done-callback`.](https://github.com/jest-community/eslint-plugin-jest/releases/tag/v24.0.0)

Fixes error `Definition for rule 'jest/no-test-callback' was not found  jest/no-test-callback` after upgrading to `eslint-plugin-jest@^24.0.0`.