### PR TITLE
feat: add react/jsx-key rule set to error

### DIFF
--- a/configurations/react.json
+++ b/configurations/react.json
@@ -62,6 +62,13 @@
       2,
       2
     ],
+    "react/jsx-key": [
+      2,
+      {
+        "checkFragmentShorthand": true,
+        "checkKeyMustBeforeSpread": true
+      }
+    ],
     "react/jsx-max-props-per-line": [
       2,
       {


### PR DESCRIPTION
Adds missing `react/jsx-key` rule and sets to error.