### PR TITLE
Moved browser and node env from base to respective configs

### DIFF
--- a/configurations/browser.js
+++ b/configurations/browser.js
@@ -1,4 +1,7 @@
 module.exports = {
+  env: {
+    browser: true
+  },
   plugins: [
     'unicorn',
   ],

--- a/configurations/eslintrc.js
+++ b/configurations/eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
   env: {
-    browser: true,
     es6: true,
-    node: true,
   },
   parser: '@babel/eslint-parser',
   parserOptions: {

--- a/configurations/node.js
+++ b/configurations/node.js
@@ -1,4 +1,7 @@
 module.exports = {
+  env: {
+    node: true
+  },
   parserOptions: {
     ecmaVersion: 2_020,
   },


### PR DESCRIPTION
Node (as well as Browser) global variables should only be available if the user opted in for Node using:
```json
"extends": [
  "canonical/node"
]
```

Let's say I'm developing for the browser. In my `.eslintrc.json` I have this:
```json
"extends": [
  "canonical",
  "canonical/browser"
]
```

Writing `const a = process;` should trigger a `no-undef` error since `process` is not available in the browser. However, without the proposed change, this line passes.