### PR TITLE
Fixed linting errors caused by accepted PR

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,9 @@
-const base = require('./configurations/eslintrc');
-
 module.exports = {
-  ...base,
+  extends: [
+    './configurations/eslintrc',
+    './configurations/node',
+  ],
   rules: {
-    ...base.rules,
     'canonical/filename-match-regex': 0,
   },
 };

--- a/bin/generate-typescript-compatibility-rules.js
+++ b/bin/generate-typescript-compatibility-rules.js
@@ -1,7 +1,9 @@
 /* eslint-disable import/order */
 
 const typescriptRules = require('@typescript-eslint/eslint-plugin').rules;
-const {builtinRules} = require('eslint/use-at-your-own-risk');
+const {
+  builtinRules,
+} = require('eslint/use-at-your-own-risk');
 
 const builtinRuleNames = Object.keys(Object.fromEntries(builtinRules));
 const typescriptRuleNames = Object.keys(typescriptRules);

--- a/compare/utilities.js
+++ b/compare/utilities.js
@@ -16,10 +16,18 @@ const getConfigurationPluginNames = async (configuration) => {
 
 const getPluginRules = (pluginName) => {
   // eslint-disable-next-line import/no-dynamic-require
-  const {rules} = require(pluginName.startsWith('@') ? pluginName + '/eslint-plugin' : 'eslint-plugin-' + pluginName);
+  const {
+    rules,
+  } = require(pluginName.startsWith('@') ? pluginName + '/eslint-plugin' : 'eslint-plugin-' + pluginName);
 
-  return Object.fromEntries(Object.entries(rules).map(([ruleName, ruleConfiguration]) => {
-    return [pluginName + '/' + ruleName, ruleConfiguration];
+  return Object.fromEntries(Object.entries(rules).map(([
+    ruleName,
+    ruleConfiguration,
+  ]) => {
+    return [
+      pluginName + '/' + ruleName,
+      ruleConfiguration,
+    ];
   }));
 };
 

--- a/configurations/browser.js
+++ b/configurations/browser.js
@@ -1,6 +1,6 @@
 module.exports = {
   env: {
-    browser: true
+    browser: true,
   },
   plugins: [
     'unicorn',

--- a/configurations/node.js
+++ b/configurations/node.js
@@ -1,6 +1,6 @@
 module.exports = {
   env: {
-    node: true
+    node: true,
   },
   parserOptions: {
     ecmaVersion: 2_020,


### PR DESCRIPTION
Thanks for accepting my previous PR.

Just noticed that it caused a lot of linting errors in the sources files themselves as the `.eslintrc.js` was relying on the `base` config to set the Node env. This PR fixes that by extending the `.eslintrc.js` with the `node` config.

I also ran `eslint . --fix`, which caused a couple minor changes. 

Note that there are still 7 linting errors (mainly `node/global-require`). It'd be great to fix them and maybe after that to make the `eslint .` command part of the test script. What do you think?