### PR TITLE
fix: make `typescript-type-checking` config work by correcting typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This package includes the following configurations:
 * [`canonical/prettier`](./configurations/prettier.js) – applies [Prettier](https://prettier.io/) formatting.
 * [`canonical/react`](./configurations/react.js) – for projects that use [React](https://facebook.github.io/react/).
 * [`canonical/typescript`](./configurations/typescript.js) – for projects that use [TypeScript](http://typescriptlang.org/).
+* [`canonical/typescript-type-checking`](./configurations/typescript-type-checking.js) – for projects that use [TypeScript](http://typescriptlang.org/) and want additional rules that require type information (rules using type information take longer to run).
 * [`canonical/vitest`](./configurations/vitest.js) – for projects that use [Vitest](https://vitest.dev/).
 * [`canonical/yaml`](./configurations/yaml.js) – for projects that use YAML.
 * [`canonical/zod`](./configurations/zod.js) – for projects that use [Zod](https://github.com/colinhacks/zod).

--- a/typescript-type-checking.js
+++ b/typescript-type-checking.js
@@ -1,9 +1,9 @@
 /* eslint-disable canonical/filename-match-exported */
 
-const typescript = require('./configurations/typescript-typed-linting');
+const typescript = require('./configurations/typescript-type-checking');
 
 typescript.rules = {
-  ...require('./configurations/typescript-typed-linting').rules,
+  ...require('./configurations/typescript-type-checking').rules,
 };
 
 module.exports = typescript;


### PR DESCRIPTION
### Current Behavior

Lint error with `typescript-type-checking` configuration.

```shell
Oops! Something went wrong! :(

ESLint: 8.15.0

Error: Cannot read config file: /Users/.../node_modules/.pnpm/registry.npmjs.org+eslint-config-canonical@40.0.4_2qtifblrazousu5zpzefcqrzza/node_modules/eslint-config-canonical/typescript-type-checking.js
Error: Cannot find module './configurations/typescript-typed-linting'

```

### Expected behaviour with this pull request

Lint without error with `typescript-type-checking` configuration.