### PR TITLE
bump eslint-plugin-vitest version to 0.0.54

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-typescript-sort-keys": "^2.1.0",
     "eslint-plugin-unicorn": "^45.0.2",
-    "eslint-plugin-vitest": "^0.0.25",
+    "eslint-plugin-vitest": "^0.0.54",
     "eslint-plugin-yml": "^1.4.0",
     "eslint-plugin-zod": "^1.4.0",
     "prettier": "^2.8.1",


### PR DESCRIPTION
Bumping to the latest version of plugin fixes some annoying bugs, particularly https://github.com/veritem/eslint-plugin-vitest/pull/32