### PR TITLE
fix(readme): make example concise

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,31 +154,7 @@ Additionally, we found it that being explicit about which formatter you are usin
 
 ```json
 {
-  "[css]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[html]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[javascript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[javascriptreact]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[json]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[markdown]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[yaml]": {
+  "[css][html][javascript][javascriptreact][json][markdown][typescript][typescriptreact][yaml]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   }
 }


### PR DESCRIPTION
VSCode allows you to combine language-specific configurations into one rule. This change follows that convention to improve the clarity here. see: https://code.visualstudio.com/docs/getstarted/settings#_multiple-languagespecific-editor-settings

EDIT: Just wanted to say how much I appreciate this part of the documentation. Configuring ESLint as a formatter in VSCode and providing the best DX can sometimes be a challenge (especially when working with prettier). This really helped me out, just wanted to make it a little cleaner