### PR TITLE
fix: wrong plugin syntax for jest config

### DIFF
--- a/configurations/jest.js
+++ b/configurations/jest.js
@@ -1,9 +1,12 @@
+const jest = require('eslint-plugin-jest');
+
 module.exports.recommended = {
-  plugins: [
-    {
-      jest: require('eslint-plugin-jest'),
-    },
-  ],
+  plugins: {
+    jest,
+  },
+  languageOptions: {
+    globals: jest.environments.globals.globals,
+  },
   rules: {
     'jest/consistent-test-it': 2,
     'jest/expect-expect': 2,

--- a/configurations/jest.js
+++ b/configurations/jest.js
@@ -1,11 +1,11 @@
 const jest = require('eslint-plugin-jest');
 
 module.exports.recommended = {
-  plugins: {
-    jest,
-  },
   languageOptions: {
     globals: jest.environments.globals.globals,
+  },
+  plugins: {
+    jest,
   },
   rules: {
     'jest/consistent-test-it': 2,


### PR DESCRIPTION
The `plugins` property should be an Object, not an Array: https://eslint.org/docs/latest/use/configure/configuration-files 

Also, jest globals were missing from the config, which caused errors such as `'expect' is not defined` when linting test files