### PR TITLE
fix: replace deprecated "env" property with "globals" for mocha config

### DIFF
--- a/configurations/mocha.js
+++ b/configurations/mocha.js
@@ -1,6 +1,8 @@
+const globals = require('globals');
+
 module.exports.recommended = {
-  env: {
-    mocha: true,
+  languageOptions: {
+    globals: globals.mocha,
   },
   plugins: {
     mocha: require('eslint-plugin-mocha'),


### PR DESCRIPTION
In ESLint Flat Config "env" is no longer supported: https://eslint.org/blog/2022/08/new-config-system-part-2/#goodbye-environments%2C-hello-globals