### PR TITLE
fix: replace deprecated "env" property with "globals" for cypress config

### DIFF
--- a/configurations/cypress.js
+++ b/configurations/cypress.js
@@ -1,9 +1,11 @@
+const cypress = require('eslint-plugin-cypress/flat');
+
 module.exports.recommended = {
-  // env: {
-  //   'cypress/globals': true,
-  // },
+  languageOptions: {
+    globals: cypress.recommended.plugins.cypress.environments.globals.globals,
+  },
   plugins: {
-    cypress: require('eslint-plugin-cypress'),
+    cypress,
   },
   rules: {
     'cypress/assertion-before-screenshot': 2,


### PR DESCRIPTION
Before, cypress globals were not being recognized due to importing the legacy version of the cypress plugin.  Now, we're importing "eslint-cypress-plugin/flat" instead of "eslint-cypress-plugin" and the "env" property has been replaced with "globals"