### PR TITLE
Import all from @typescript-eslint/parser

### DIFF
--- a/configurations/typescript.js
+++ b/configurations/typescript.js
@@ -1,7 +1,7 @@
 import * as typescriptCompatibility from './typescript-compatibility.js';
 import stylisticPlugin from '@stylistic/eslint-plugin';
 import eslintPlugin from '@typescript-eslint/eslint-plugin';
-import eslintParser from '@typescript-eslint/parser';
+import * as eslintParser from '@typescript-eslint/parser';
 import canonicalPlugin from 'eslint-plugin-canonical';
 
 // TODO add .d.ts files


### PR DESCRIPTION
Before the change I was receiving the following error:

```
SyntaxError: The requested module 'file:///./node_modules/@typescript-eslint/parser/dist/index.js' does not provide an export named 'default'
```